### PR TITLE
Actualización de la gestión de los cometidos

### DIFF
--- a/app/Http/Requests/Call/UpdateCallRequest.php
+++ b/app/Http/Requests/Call/UpdateCallRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Call;
 
+use App\Rules\Samu\CallRegulation;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -33,7 +34,10 @@ class UpdateCallRequest extends FormRequest
             'police_intervention'=> 'nullable|boolean',
             'information'       => 'required|string|min:3|max:5000',
             'commune_id'        => 'nullable|exists:communes,id',
-            'key_id'            => 'required|exists:samu_keys,id',
+            'key_id'            => [
+                'required_if:classification,T1,T2,NM|exists:samu_keys,id',
+                new CallRegulation($this->route('call')->call_id, $this->classification, $this->key_id)
+            ],
             'address'           => 'nullable|string|min:0|max:255',
             'latitude'          => 'nullable|numeric',
             'longitude'         => 'nullable|numeric',

--- a/app/Http/Requests/Event/EventStoreRequest.php
+++ b/app/Http/Requests/Event/EventStoreRequest.php
@@ -26,7 +26,6 @@ class EventStoreRequest extends FormRequest
         return [
             'mobile_id'             => 'required|exists:samu_mobiles,id',
             'key_id'                => 'required|exists:samu_keys,id',
-            'call_id'               => 'required|exists:samu_calls,id',
             'return_key_id'         => 'nullable|exists:samu_keys,id',
             'observation'           => 'nullable|string|min:0|max:5000',
             'external_crew'         => 'nullable|string|min:0|max:5000',
@@ -69,5 +68,17 @@ class EventStoreRequest extends FormRequest
             'treatment'         => 'nullable|string|min:0|max:5000',
             'observation_sv'    => 'nullable|string|min:0|max:5000',
         ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'patient_unknown' => isset($this->patient_unknown) ? true : false,
+        ]);
     }
 }

--- a/app/Http/Requests/Event/EventUpdateRequest.php
+++ b/app/Http/Requests/Event/EventUpdateRequest.php
@@ -71,4 +71,16 @@ class EventUpdateRequest extends FormRequest
             'save_close'        => 'nullable|string'
         ];
     }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'patient_unknown'   => isset($this->patient_unknown) ? true : false,
+        ]);
+    }
 }

--- a/app/Models/Samu/Call.php
+++ b/app/Models/Samu/Call.php
@@ -60,7 +60,7 @@ class Call extends Model implements Auditable
 
     public function events()
     {
-        return $this->belongsToMany(Event::class,'samu_call_event');
+        return $this->hasMany(Event::class,);
     }
 
     public function shift()

--- a/app/Models/Samu/Event.php
+++ b/app/Models/Samu/Event.php
@@ -15,7 +15,6 @@ use App\Models\User;
 use App\Models\Commune;
 use App\Models\CodConIdentifierType;
 use App\Models\Organization;
-use Illuminate\Support\Carbon;
 
 class Event extends Model implements Auditable
 {   
@@ -30,6 +29,7 @@ class Event extends Model implements Auditable
         'date',
         
         'shift_id',
+        'call_id',
         'key_id',
         'return_key_id',
         'mobile_in_service_id',
@@ -100,8 +100,7 @@ class Event extends Model implements Auditable
     ];
 
     protected $appends = [
-        'color',
-        'last_call'
+        'color'
     ];
 
     public function shift() 
@@ -112,6 +111,11 @@ class Event extends Model implements Auditable
     public function calls()
     {
         return $this->belongsToMany(Call::class,'samu_call_event');
+    }
+
+    public function call()
+    {
+        return $this->belongsTo(Call::class);
     }
 
     public function key()
@@ -174,10 +178,5 @@ class Event extends Model implements Auditable
         if($this->return_base_at)           $color = 'info';
         if($this->on_base_at)               $color = 'success';
         return $color;
-    }
-
-    public function getLastCallAttribute()
-    {
-        return $this->calls->last();
     }
 }

--- a/app/Rules/Samu/CallRegulation.php
+++ b/app/Rules/Samu/CallRegulation.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Rules\Samu;
+
+use App\Models\Samu\Call;
+use Illuminate\Contracts\Validation\Rule;
+
+class CallRegulation implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct($call_id, $classification, $key)
+    {
+        $this->call_id = $call_id;
+        $this->classification = $classification;
+        $this->key = $key;
+        $this->msg = '';
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if($this->call_id == null)
+        {
+            if($this->classification == 'OT')
+            {
+                $pass = ($this->key == null) ? true : false;
+                $this->msg = 'Si la llamada es tipo OT no debe ingresar la clave';
+            }
+            elseif($this->classification == null)
+            {
+                $pass = false;
+                $this->msg = 'Por favor clasifique la llamada';
+            } 
+            else
+            {
+                $pass = ($this->key != null) ? true : false;
+            }
+        }
+        else
+        {
+            $pass = ($this->classification == null && $this->key == null) ? true : false;
+            $this->msg = 'Si la llamada hace referencia a otra, no debe clasificarla ni seleccionar clave';
+        }
+        return $pass;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return $this->msg;
+    }
+}

--- a/database/migrations/2022_03_16_133340_add_call_to_samu_events.php
+++ b/database/migrations/2022_03_16_133340_add_call_to_samu_events.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCallToSamuEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('samu_events', function (Blueprint $table) {
+            $table->foreignId('call_id')
+                ->after('shift_id')
+                ->nullable()
+                ->constrained('samu_calls');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2022_03_16_133517_migrate_calls_to_samu_events.php
+++ b/database/migrations/2022_03_16_133517_migrate_calls_to_samu_events.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Samu\Event;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MigrateCallsToSamuEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $events = Event::all();
+
+        foreach($events as $event)
+        {
+            if($event->calls->count() > 0)
+            {
+                $calls = $event->calls()->orderBy('samu_call_event.call_id', 'asc')->get();
+
+                $firstCall = $calls->first();
+
+                $event->update([
+                    'call_id' => $firstCall->id
+                ]);
+
+                $otherCalls = $calls->whereNotIn('id', $firstCall->id);
+
+                foreach($otherCalls as $call)
+                {
+                    $call->update([
+                        'call_id' => $firstCall->id
+                    ]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/seeders/SamuSeeder.php
+++ b/database/seeders/SamuSeeder.php
@@ -105,7 +105,7 @@ class SamuSeeder extends Seeder
             'return_key_id' => 2,
         ]);
 
-        $call2->events()->attach($event);
+        // $call2->events()->save($event);
 
     }
 }

--- a/resources/views/samu/call/form.blade.php
+++ b/resources/views/samu/call/form.blade.php
@@ -138,14 +138,19 @@
 <div class="form-row">
     <fieldset class="form-group col-md-3">
         <label for="for-classification">Clasificación</label>
-        <select class="form-control form-control-sm @error('classification') is-invalid @enderror" name="classification" id="for-classification" {{ optional($call)->classification == 'OT' ? 'disabled readonly' : '' }}>
+        @if($call->classification != 'OT')
+        <select class="form-control form-control-sm @error('classification') is-invalid @enderror" name="classification" id="for-classification">
             <option value="">Selecciona una Clasificación</option>
-            <option value="T1" {{ optional($call)->classification == 'T1' ? 'selected' : '' }}>T1</option>
-            <option value="T2" {{ optional($call)->classification == 'T2' ? 'selected' : '' }}>T2</option>
-            <option value="NM" {{ optional($call)->classification == 'NM' ? 'selected' : '' }}>NM</option>
-            <option value="OT" {{ optional($call)->classification == 'OT' ? 'selected' : '' }}>OT</option>
+            <option value="T1" {{ old('classification', optional($call)->classification) == 'T1' ? 'selected' : '' }}>T1</option>
+            <option value="T2" {{ old('classification', optional($call)->classification) == 'T2' ? 'selected' : '' }}>T2</option>
+            <option value="NM" {{ old('classification', optional($call)->classification) == 'NM' ? 'selected' : '' }}>NM</option>
+            <option value="OT" {{ old('classification', optional($call)->classification) == 'OT' ? 'selected' : '' }}>OT</option>
         </select>
         <small id="for-classification" class="form-text text-danger">Si hace referencia a otra llamada, no debe clasificarla.</small>
+        @else
+            <input type="text" class="form-control form-control-sm" name="classification" id="for-classification" readonly
+                value="{{ optional($call)->classification }}" >
+        @endif
         @error('classification')
             <div class="text-danger">
                 <small>{{ $message }}</small>

--- a/resources/views/samu/event/create.blade.php
+++ b/resources/views/samu/event/create.blade.php
@@ -5,40 +5,103 @@
 @include('samu.nav')
 
 <h3 class="mb-3">
-    <i class="fas fa-car-crash"></i> Nuevo cometido {{ $nextCounter }}
-    @if($call)
-        - Relacionada con la llamada ID: {{ $call->id }}
+    @if(request()->routeIs('samu.event.create'))
+        <i class="fas fa-car-crash"></i> 
+        Nuevo cometido {{ $nextCounter }}
+        @if($call)
+            - Relacionada con la llamada ID: {{ $call->id }}
+        @endif
+    @else
+        <i class="fas fa-car-crash"></i>
+        @if($event)
+            Duplicando cometido Nº {{ $event->id }}, con nuevo Nº {{ $nextCounter }}
+        @endif
     @endif
 </h3>
-      
-<form method="post" action="{{ route('samu.event.store') }}">
 
-    <h4 class="mb-3">Asociar cometido a una llamada</h4>
+@if($event)
+<h4 class="mt-3">Llamadas relacionadas a este cometido</h4>
 
-    <div class="form-row">
-        <fieldset class="form-group col-md-12">
-            <label for="for-call">Ultimas 20 llamadas clasificadas*</label>
-            <select class="form-control" name="call_id" id="for-call" required>
-                <option value="">Selecciona una llamada</option>
-                @foreach($calls as $callItem)
-                    <option value="{{ $callItem->id }}" {{ old('call_id', $event ? optional($event)->last_call->id : optional($call)->id) == $callItem->id ? 'selected' : '' }}>
-                    @if($callItem->events->isNotEmpty())
-                     &nbsp;
+<div class="table-responsive">
+
+    <table class="table table-sm table-bordered table-striped">
+        <thead>
+            <tr class="text-center table-primary">
+                <th>Id</th>
+                <th>Clasificación</th>
+                <th nowrap>Hora</th>
+                <th>Solicitante</th>
+                <th>Información telefonica</th>
+                <th>Dirección</th>
+                <th>Teléfono</th>
+                <th>Receptor de llamada</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if($event->call)
+                <tr>
+                    <td class="text-center">
+                        <a href="{{ route('samu.call.edit', $event->call) }}" class="btn btn-sm btn-primary">
+                            <i class="fas fa-edit"></i> {{ $event->call->id }}
+                        </a>
+                    </td>
+                    <td>
+                        {{ $event->call->classification }} 
+                    </td>
+                    <td>{{ $event->call->hour }}</td>
+                    <td>{{ $event->call->applicant }}</td>
+                    <td>
+                        {{ $event->call->sex_abbr }} 
+                        {{ $event->call->age_format }} 
+                        {{ $event->call->information }}
+                    </td>
+                    <td>{{ $event->call->address }}</td>
+                    <td>{{ $event->call->telephone }}</td>
+                    <td>{{ $event->call->receptor->officialFullName }}</td>
+                </tr>
+                @foreach($event->call->associatedCalls as $associatedCall)
+                <tr>
+                    <td class="text-center">
+                        <a href="{{ route('samu.call.edit', $associatedCall) }}" class="btn btn-sm btn-outline-primary">
+                            <i class="fas fa-edit"></i> {{ $associatedCall->id }}
+                        </a>
+                    </td>
+                    <td>
+                        {{ $associatedCall->classification }}
+                        @if($associatedCall->referenceCall)
+                        Referencia a: 
+                        <a href="{{ route('samu.call.edit',$associatedCall->referenceCall) }}">
+                            {{ $associatedCall->referenceCall->id }}
+                        </a>
                     @endif
-                        <b>ID: {{ $callItem->id }}</b>
-                        @if($callItem->events->isNotEmpty())
-                            - COM: 
-                            {{ implode(',', $callItem->events->pluck('id')->toArray() )}}
-                        @endif
-                        - CLAS: {{ $callItem->classification }} 
-                        - DIR: {{ $callItem->address }} 
-                        ( {{ $callItem->information }} )
-                    </option>
+                    </td>
+                    <td>{{ $associatedCall->hour }}</td>
+                    <td>{{ $associatedCall->applicant }}</td>
+                    <td>
+                        {{ $associatedCall->sex_abbr }} 
+                        {{ $associatedCall->age_format }} 
+                        {{ $associatedCall->information }}
+                    </td>
+                    <td>{{ $associatedCall->address }}</td>
+                    <td>{{ $associatedCall->telephone }}</td>
+                    <td>{{ $associatedCall->receptor->officialFullName }}</td>
+                </tr>
                 @endforeach
-            </select>
-        </fieldset>
-    </div>
+            @else 
+                <tr>
+                    <td class="text-center" colspan="8">
+                        No hay llamadas relacionadas a este cometido.
+                    </td>
+                </tr>
+            @endif
+        </tbody>
+    </table>
 
+</div>
+@endif
+
+<form method="post" action="{{ request()->routeIs('samu.event.create') ? route('samu.event.store', $call) : route('samu.event.store.duplicate', $event) }}">
+ 
     @csrf
     @method('POST')
 
@@ -49,9 +112,17 @@
         'shift' => $shift,
     ])
 
-    <button type="submit" class="btn btn-primary">Guardar</button>
+    <button type="submit" class="btn btn-primary">
+        @if(request()->routeIs('samu.event.create'))
+            <i class="fas fa-save"></i> Guardar
+        @else
+            <i class="fas fa-copy"></i> Duplicar
+        @endif
+    </button>
 
-    <a href="{{ route('samu.event.index') }}" class="btn btn-outline-secondary">Cancelar</a>
+    <a href="{{ route('samu.event.index') }}" class="btn btn-outline-secondary">
+        Cancelar
+    </a>
 
 </form>
 

--- a/resources/views/samu/event/edit.blade.php
+++ b/resources/views/samu/event/edit.blade.php
@@ -6,7 +6,14 @@
 
 <div class="row">
     <div class="col">
-        <h3 class="mb-3"><i class="fas fa-car-crash"></i> Editar cometido {{ $event->id }}</h3>
+        <h3 class="mb-3">
+            <i class="fas fa-car-crash"></i> Editar cometido {{ $event->id }}
+            @if($event->call)
+                - Llamada ID: {{ $event->call->id }}
+            @else 
+                - Sin llamada asociada
+            @endif
+        </h3>
     </div>
     <div class="col text-right">
         @can('SAMU administrador')
@@ -87,7 +94,28 @@
             </tr>
         </thead>
         <tbody>
-            @foreach($event->calls as $call)
+            @if($event->call)
+            <tr>
+                <td class="text-center">
+                    <a href="{{ route('samu.call.edit', $event->call) }}" class="btn btn-sm btn-primary">
+                        <i class="fas fa-edit"></i> {{ $event->call->id }}
+                    </a>
+                </td>
+                <td>
+                    {{ $event->call->classification }}
+                </td>
+                <td>{{ $event->call->hour }}</td>
+                <td>{{ $event->call->applicant }}</td>
+                <td>
+                    {{ $event->call->sex_abbr }} 
+                    {{ $event->call->age_format }} 
+                    {{ $event->call->information }}
+                </td>
+                <td>{{ $event->call->address }}</td>
+                <td>{{ $event->call->telephone }}</td>
+                <td>{{ $event->call->receptor->officialFullName }}</td>
+            </tr>
+            @foreach($event->call->associatedCalls as $call)
             <tr>
                 <td class="text-center">
                     <a href="{{ route('samu.call.edit',$call) }}" class="btn btn-sm btn-outline-primary">
@@ -95,12 +123,18 @@
                     </a>
                 </td>
                 <td>
-                    {{ $call->classification }} 
-                    @if($call->classification != 'OT')
-                        - Event: 
-                        @foreach($call->events as $event)
-                            <a href="{{ route('samu.event.edit', $event) }}" class="link-primary"> {{ $event->id }}</a>, 
-                        @endforeach
+                    @if($call->classification)
+                        {{ $call->classification }} 
+                        @if($call->classification != 'OT')
+                            - Evento:
+                            @foreach($call->events as $event)
+                                <a href="{{ route('samu.event.edit', $event) }}" class="link-primary"> {{ $event->id }}</a>, 
+                            @endforeach
+                        @endif
+                    @endif
+
+                    @if($call->referenceCall)
+                        Referencia a: <a href="{{ route('samu.call.edit',$call->referenceCall) }}">{{ $call->referenceCall->id }}</a>
                     @endif
                 </td>
                 <td>{{ $call->hour }}</td>
@@ -111,40 +145,14 @@
                 <td>{{ $call->telephone }}</td>
                 <td>{{ $call->receptor->officialFullName }}</td>
             </tr>
-            @if($call->associatedCalls->isNotEmpty())
-                @foreach($call->associatedCalls->reverse() as $call)
-                <tr>
-                    <td class="text-center">
-                        <a href="{{ route('samu.call.edit',$call) }}" class="btn btn-sm btn-outline-primary">
-                            <i class="fas fa-edit"></i> {{ $call->id }}
-                        </a>
-                    </td>
-                    <td>
-                        @if($call->classification)
-                            {{ $call->classification }} 
-                            @if($call->classification != 'OT')
-                                - Evento: 
-                                @foreach($call->events as $event)
-                                    <a href="{{ route('samu.event.edit', $event) }}" class="link-primary"> {{ $event->id }}</a>, 
-                                @endforeach
-                            @endif
-                        @endif
-
-                        @if($call->referenceCall)
-                            Referencia a: <a href="{{ route('samu.call.edit',$call->referenceCall) }}">{{ $call->referenceCall->id }}</a>
-                        @endif
-                    </td>
-                    <td>{{ $call->hour }}</td>
-                    <td>{{ $call->applicant }}</td>
-                    <td>{{ $call->information }}</td>
-                    
-                    <td>{{ $call->address }}</td>
-                    <td>{{ $call->telephone }}</td>
-                    <td>{{ $call->receptor->officialFullName }}</td>
-                </tr>
-                @endforeach
+            @endforeach
+            @else
+            <tr>
+                <td class="text-center" colspan="8">
+                    No hay llamadas relacionadas a este cometido
+                </td>
+            </tr>
             @endif
-            @endforeach   
         </tbody>
     </table>
 

--- a/resources/views/samu/event/form.blade.php
+++ b/resources/views/samu/event/form.blade.php
@@ -1,4 +1,4 @@
-<h4> Asignación de seguimiento y horarios</h4>
+<h4>Asignación de seguimiento y horarios</h4>
 <div class="form-row">
 
     <fieldset class="form-group col-md-3">

--- a/resources/views/samu/event/index.blade.php
+++ b/resources/views/samu/event/index.blade.php
@@ -57,10 +57,8 @@
     </div>
 </div>
 
-<h3 class="mb-3"><i class="fas fa-phone"></i> Llamadas pendientes (sin cometido asociado)
-    <a class="btn btn-success float-right" href="{{ route('samu.event.create') }}">
-        <i class="fas fa-plus"></i> Crear cometido
-    </a>
+<h3 class="mb-3">
+    <i class="fas fa-phone"></i> Llamadas pendientes (sin cometido asociado)
 </h3>
 @include('samu.call.partials.list',['calls' => $calls, 'edit' => true, 'createEvent' => true])
 

--- a/resources/views/samu/event/partials/index.blade.php
+++ b/resources/views/samu/event/partials/index.blade.php
@@ -38,9 +38,12 @@
                 <td>{{ $event->counter }} </td>
                 <td>{{ optional($event->departure_at)->format('H:i') }} </td>
                 <td>
-                    @foreach($event->calls as $call)
-                        <a href="{{ route('samu.call.edit',$call) }}">{{ $call->id }}</a>,
-                    @endforeach
+                    @if($event->call)
+                        <a href="{{ route('samu.call.edit', $event->call) }}">{{ $event->call->id }}</a>,
+                        @foreach($event->call->associatedCalls as $associatedCall)
+                            <a href="{{ route('samu.call.edit', $associatedCall) }}">{{ $associatedCall->id }}</a>,
+                        @endforeach
+                    @endif
                 </td>
                 <td nowrap>
                     {{ optional($event->mobile)->code }} 
@@ -61,9 +64,14 @@
             <tr class="table-{{ $event->color }}">
                 <td class="text-center"><i class="fas fa-phone"></i></td>
                 <td colspan="9">
-                    @foreach($event->calls as $call)
-                    <li>{{ $call->sex_abbr }} {{ $call->age_format }} {{ $call->information }}</li>
-                    @endforeach
+                    @if($event->call)
+                        <li>{{ $event->call->sex_abbr }} {{ $event->call->age_format }} {{ $event->call->information }}</li>
+                        @foreach($event->call->associatedCalls as $associatedCall)
+                            <li>{{ $associatedCall->sex_abbr }} {{ $associatedCall->age_format }} {{ $associatedCall->information }}</li>
+                        @endforeach
+                    @else
+                        <li>No hay llamadas asociadas</li>
+                    @endif
                 </td>
             </tr>
             <tr>

--- a/resources/views/samu/event/report.blade.php
+++ b/resources/views/samu/event/report.blade.php
@@ -30,22 +30,42 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach($event->calls as $call)
+                @if($event->call)
+                    <tr>
+                        <td class="center">{{ $event->call->hour->format('H:i') }}</td>
+                        <td>{{ $event->call->telephone }}</td>
+                        <td>{{ $event->call->address }} {{ optional($event->call->commune)->name }}</td>
+                        <td>{{ $event->call->applicant }}</td>
+                        <td class="center">{{ $event->call->classification }}</td>
+                        <td class="center">{{ $event->call->receptor_id }}</td>
+                    </tr>
+                    <tr>
+                        <td colspan="6">{{ $event->call->sex_abbr }} {{ $event->call->age_format }} {{ $event->call->information }}</td>
+                    </tr>
+                    @foreach($event->call->associatedCalls as $associatedCall)
+                    <tr>
+                        <td class="center">{{ $associatedCall->hour->format('H:i') }}</td>
+                        <td>{{ $associatedCall->telephone }}</td>
+                        <td>{{ $associatedCall->address }} {{ optional($associatedCall->commune)->name }}</td>
+                        <td>{{ $associatedCall->applicant }}</td>
+                        <td class="center">{{ $associatedCall->classification }}</td>
+                        <td class="center">{{ $associatedCall->receptor_id }}</td>
+                    </tr>
+                    <tr>
+                        <td colspan="6">{{ $associatedCall->sex_abbr }} {{ $associatedCall->age_format }} {{ $associatedCall->information }}</td>
+                    </tr>
+                    @endforeach
+                @else
                 <tr>
-                    <td class="center">{{ $call->hour->format('H:i') }}</td>
-                    <td>{{ $call->telephone }}</td>
-                    <td>{{ $call->address }} {{ optional($call->commune)->name }}</td>
-                    <td>{{ $call->applicant }}</td>
-                    <td class="center">{{ $call->classification }}</td>
-                    <td class="center">{{ $call->receptor_id }}</td>
+                    <td class="center" colspan="6">
+                        No hay llamadas
+                    </td>
                 </tr>
-                <tr>
-                    <td colspan="6">{{ $call->sex_abbr }} {{ $call->age_format }} {{ $call->information }}</td>
-                </tr>
-                @if(!$loop->last)
-                    <tr><td colspan="6" style="border-left: 1px solid white; border-right: 1px solid white;">&nbsp;</td></tr>
                 @endif
-                @endforeach
+                {{-- @if(!$loop->last)
+                    <tr><td colspan="6" style="border-left: 1px solid white; border-right: 1px solid white;">&nbsp;</td></tr>
+                    @endif 
+                --}}
             </tbody>
         </table>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -548,9 +548,10 @@ Route::prefix('samu')->name('samu.')->middleware('auth')->group(function () {
 	->middleware('permission:SAMU administrador|SAMU despachador')
 	->group(function () {
 		Route::get('/', 			[EventController::class, 'index'])->name('index');
-		Route::get('/create/duplicate/{event}', [EventController::class, 'create'])->name('duplicate');
+		Route::get('/{event}/duplicate', [EventController::class, 'create'])->name('duplicate');
 		Route::get('/create/{call?}', [EventController::class, 'create'])->name('create');
-		Route::post('/store',		[EventController::class, 'store'])->name('store');
+		Route::post('/store/{call?}', [EventController::class, 'store'])->name('store');
+		Route::post('/store/{event?}/duplicate', [EventController::class, 'store'])->name('store.duplicate');
 		Route::get('/edit/{event}', [EventController::class, 'edit'])->name('edit');
 		Route::put('/update/{event}',[EventController::class, 'update'])->name('update');
 		Route::delete('/{event}', 	[EventController::class, 'destroy'])->name('destroy');


### PR DESCRIPTION
**Funcionalidades**
- Agrega migración para crear call_id en la tabla `samu_events`.
- Crear script para definir call_id en la tablas `samu_events` según las llamadas relacionadas al evento o cometido.
- Ajusta boton para crear y duplicar cometido.
- Se elimina boton de crear cometido. 
- Se lista llamadas relacionadas al duplicar cometido.
- Se agrega un Rule `CallRegulation` para regular las llamadas.
- Se ajusta vista de report cometido y edit cometido.
- En el modelo `Call` se ajusta relación events a `hasMany`. Es decir, 1 Call tiene N Events.

**Notas**
- Se comenta línea en `SamuSeeder` para evitar conflicto, descomentar a futuro.
- Se persiste relacion calls en `Events`, a futuro debe eliminarse.
- A futuro debe eliminarse la tabla `samu_call_event`.

