### PR TITLE
SAMU - móviles en servicio, no mostrar personal retirado en el despacho

### DIFF
--- a/app/Models/Samu/Call.php
+++ b/app/Models/Samu/Call.php
@@ -61,7 +61,7 @@ class Call extends Model implements Auditable
 
     public function events()
     {
-        return $this->hasMany(Event::class,);
+        return $this->hasMany(Event::class);
     }
 
     public function shift()

--- a/app/Models/Samu/MobileCrew.php
+++ b/app/Models/Samu/MobileCrew.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 class MobileCrew extends pivot
 {
     use HasFactory;
-   
+
     protected $table="samu_mobile_crew";
 
     protected $fillable = [
@@ -43,4 +43,11 @@ class MobileCrew extends pivot
         return $this->BelongsTo(JobType::class);
     }
 
+    public function getCrewStatusAttribute()
+    {
+        if($this->leaves_at == null || $this->leaves_at > now())
+            return 'success';
+        else
+            return 'danger';
+    }
 }

--- a/app/Models/Samu/MobileInService.php
+++ b/app/Models/Samu/MobileInService.php
@@ -77,10 +77,22 @@ class MobileInService extends Model implements Auditable
                     ->withTimestamps();
     }
 
+    public function currentCrew()
+    {
+        return $this->belongsToMany(User::class,'samu_mobile_crew','mobiles_in_service_id')
+            ->using(MobileCrew::class)
+            ->wherePivot('leaves_at', '=', null)
+            ->withPivot('id','job_type_id','assumes_at','leaves_at')
+            ->orWhere(function($query) {
+                $query->where('mobiles_in_service_id', $this->id)
+                    ->where('leaves_at', '>', now());
+            })
+            ->withTimestamps();
+    }
 
     public function follows()
     {
-        return $this->belongsToMany(Follow::class,'samu_follow_mis');    
+        return $this->belongsToMany(Follow::class,'samu_follow_mis');
     }
 
     public function events()
@@ -103,7 +115,7 @@ class MobileInService extends Model implements Auditable
         }
         return $total;
     }
-    
+
     public function getLastEventAttribute()
     {
         return $this->events->where('status', true)->last();

--- a/app/Observers/Samu/EventObserver.php
+++ b/app/Observers/Samu/EventObserver.php
@@ -20,12 +20,12 @@ class EventObserver
     public function creating(Event $event)
     {
         $shift = Shift::whereStatus(true)->first();
-        
+
         // Event information
         $counter = EventCounter::useNext();
         $event->counter   = $counter->counter;
         $event->date      = $counter->date;
-        
+
         $event->creator()->associate(auth()->user());
         $event->shift()->associate($shift);
 
@@ -40,12 +40,12 @@ class EventObserver
         if($shift && $event->mobileInService)
         {
             $newPosition = $shift->mobilesInService->where('status', true)->count() + 1;
-            
+
             $mobileExit = $event->mobileInService;
             $mobileExit->update([
                 'position' => $newPosition
             ]);
-            
+
             MobileInService::reorder($shift);
         }
     }
@@ -63,7 +63,7 @@ class EventObserver
 
         if($isMobileInService)
         {
-            foreach($isMobileInService->crew as $mobilecrew)
+            foreach($isMobileInService->currentCrew as $mobilecrew)
             {
                 EventUser::create([
                     'event_id'              => $event->id,

--- a/resources/views/livewire/samu/mobile-crew.blade.php
+++ b/resources/views/livewire/samu/mobile-crew.blade.php
@@ -1,9 +1,9 @@
 <div class="row">
-    
+
     <div class="col-md-8 col-12">
         <h4>Tripulación</h4>
-        
-        <table class="table"> 
+
+        <table class="table">
             <thead class="thead-light">
                 <tr>
                     <th width="54"></th>
@@ -16,7 +16,7 @@
             </thead>
             <tbody>
                 @foreach($mobileInService->crew as $tripulant)
-                <tr>
+                <tr class="table-{{ $tripulant->pivot->crew_status }}">
                     <td>
                     @if($mobileInService->shift->status == true)
                     <a class="btn btn-outline-primary btn-sm" href="{{route('samu.mobileinservice.crewedit', $tripulant->pivot->id) }}">
@@ -40,13 +40,13 @@
             </tbody>
         </table>
 
-        
+
     </div>
     <div class="col-12 col-md-4">
         @if($mobileInService->shift->status == true)
-        <div class="form-row"> 
+        <div class="form-row">
             <fieldset class="col-12 mb-1">
-                <label for="for-user-id">Funcionario</label>         
+                <label for="for-user-id">Funcionario</label>
                 <select class="form-control" wire:model='user_id' required="required">
                     <option value=""></option>
                     @foreach($users as $user => $id)
@@ -55,7 +55,7 @@
                 </select>
                 @error('user_id') <span class="error">{{ $message }}</span> @enderror
             </fieldset>
-    
+
             <fieldset class="col-12">
                 <label for="for-job-type-id">Función</label>
                 <select class="form-control" wire:model="job_type_id">
@@ -64,21 +64,21 @@
                     <option value="{{ $jt->id }}">{{ $jt->name }}</option>
                     @endforeach
                 </select>
-                @error('job_type_id') <span class="error">{{ $message }}</span> @enderror    
+                @error('job_type_id') <span class="error">{{ $message }}</span> @enderror
             </fieldset>
-    
+
             <fieldset class="col-6">
                 <label for="for-assumes-at">Asume</label>
                 <input type="datetime-local" class="form-control" wire:model="assumes_at">
                 @error('assumes_at') <span class="error">{{ $message }}</span> @enderror
             </fieldset>
-    
+
             <fieldset class="col-6 mb-3">
                 <label for="for-leaves-at">Se retira</label>
                 <input type="datetime-local" class="form-control" wire:model="leaves_at">
                 @error('leaves_at') <span class="error">{{ $message }}</span> @enderror
             </fieldset>
-            
+
             <fieldset class="col-12">
                 @if($mobileInService->shift->status == true)
                 <button wire:click="store()" class="form-control btn btn-success"><i class="fas fa-plus"></i> Agregar tripulación</button>

--- a/resources/views/samu/event/index.blade.php
+++ b/resources/views/samu/event/index.blade.php
@@ -26,19 +26,20 @@
                         @if(!$mis->status)
                             {{ $mis->observation }}
                         @else
-                            @foreach($mis->crew as $tripulant)
+                            @foreach($mis->currentCrew as $tripulant)
                             {{ $tripulant->officialFullName }} <span class="badge bg-secondary text-white">{{ substr($tripulant->pivot->jobType->name,0,1) }}</span>
                             @endforeach
                         @endif
+                        <br>
                     </td>
                     <td>{{ $mis->o2 }}</td>
                     <td nowrap>
                         @if($mis->lunch_start_at AND !$mis->lunch_end_at)
-                            {{ $mis->lunch_start_at->format('H:i')}} - 
+                            {{ $mis->lunch_start_at->format('H:i')}} -
                             {{ now()->diff($mis->lunch_start_at->copy()->addMinutes('45'))->format('%I') }}"
                         @elseif($mis->lunch_end_at)
-                            {{ $mis->lunch_start_at->format('H:i')}} - 
-                            {{ $mis->lunch_end_at->format('H:i')}} - 
+                            {{ $mis->lunch_start_at->format('H:i')}} -
+                            {{ $mis->lunch_end_at->format('H:i')}} -
                             {{ $mis->lunch_start_at->diff($mis->lunch_end_at)->format('%I') }}"
                         @endif
                     </td>

--- a/resources/views/samu/mobileinservice/partials/list.blade.php
+++ b/resources/views/samu/mobileinservice/partials/list.blade.php
@@ -27,7 +27,7 @@
                 <td>{{ $mis->type }}</td>
                 <td>{{ $mis->status ? 'Activo' : 'Inactivo'  }}</td>
                 <td>{{ $mis->o2 }}</td>
-                <td>{{ $mis->observation}}</td>
+                <td>{{ $mis->observation }}</td>
                 <td>
                     @if($editLunch)
                         @livewire('samu.lunch',['mis' => $mis])


### PR DESCRIPTION
**Funcionalidades**
- Agrega al despacho para que solo se listen los tripulantes activos.
- Agrega color a l  fila donde aparece los tripulantes al listar las móviles y sus tripulantes, que refiere si el tripulante esta activo o no (si se retiró o no).
- Al crear o duplicar el evento solo se copian los tripulantes activos de la móvil seleccionada (o que no se han retirado).

Hace referencia al issue #55 